### PR TITLE
#82 Contract Summary Tx processing stucks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Visioning](http://semver.org/spec/v2.0.0.h
 
 ## [0.3.0] - Bitcoin pump, dump, contract summary
 ### Added
+- [#108](/../../issues/108) Create API for search results preview
 - [#106](/../../issues/106) Add filter params for search api
 - [#84](/../../issues/84) API: bitcoin endpoints
 - [#98](/../../issues/98) Make chain items retrivial caps non-depended
 - [#85](/../../issues/85) Bitcoin pump/dump and bitcoin contract summary docker images, dockerhub
 ### Fixed
+- [#113](/../../issues/113) Make search API logic dependent of existing keyspaces
 - [#99](/../../issues/99) Pump stuck if chain reorganization bundles number exceed history stack size
 
 

--- a/cassandra-service/src/main/kotlin/fund/cyber/cassandra/bitcoin/repository/UpdateContractSummaryRepository.kt
+++ b/cassandra-service/src/main/kotlin/fund/cyber/cassandra/bitcoin/repository/UpdateContractSummaryRepository.kt
@@ -19,7 +19,7 @@ interface BitcoinUpdateContractSummaryRepository : ReactiveCrudRepository<CqlBit
     fun findByHash(hash: String): Mono<CqlBitcoinContractSummary>
 
     @Consistency(value = ConsistencyLevel.LOCAL_QUORUM)
-    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlBitcoinContractSummary> = Flux.fromIterable(hashes)
+    fun findAllByHash(hashes: Iterable<String>): Flux<CqlBitcoinContractSummary> = Flux.fromIterable(hashes)
         .flatMap { hash -> findByHash(hash) }
 
     /**

--- a/cassandra-service/src/main/kotlin/fund/cyber/cassandra/bitcoin/repository/UpdateContractSummaryRepository.kt
+++ b/cassandra-service/src/main/kotlin/fund/cyber/cassandra/bitcoin/repository/UpdateContractSummaryRepository.kt
@@ -19,7 +19,8 @@ interface BitcoinUpdateContractSummaryRepository : ReactiveCrudRepository<CqlBit
     fun findByHash(hash: String): Mono<CqlBitcoinContractSummary>
 
     @Consistency(value = ConsistencyLevel.LOCAL_QUORUM)
-    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlBitcoinContractSummary>
+    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlBitcoinContractSummary> = Flux.fromIterable(hashes)
+        .flatMap { hash -> findByHash(hash) }
 
     /**
      * Return {@code true} if update was successful.

--- a/cassandra-service/src/main/kotlin/fund/cyber/cassandra/ethereum/repository/UpdateContractSummaryRepository.kt
+++ b/cassandra-service/src/main/kotlin/fund/cyber/cassandra/ethereum/repository/UpdateContractSummaryRepository.kt
@@ -20,7 +20,7 @@ interface EthereumUpdateContractSummaryRepository : ReactiveCrudRepository<CqlEt
     fun findByHash(hash: String): Mono<CqlEthereumContractSummary>
 
     @Consistency(value = ConsistencyLevel.LOCAL_QUORUM)
-    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlEthereumContractSummary> = Flux.fromIterable(hashes)
+    fun findAllByHash(hashes: Iterable<String>): Flux<CqlEthereumContractSummary> = Flux.fromIterable(hashes)
         .flatMap { hash -> findByHash(hash) }
 
     /**

--- a/cassandra-service/src/main/kotlin/fund/cyber/cassandra/ethereum/repository/UpdateContractSummaryRepository.kt
+++ b/cassandra-service/src/main/kotlin/fund/cyber/cassandra/ethereum/repository/UpdateContractSummaryRepository.kt
@@ -20,7 +20,8 @@ interface EthereumUpdateContractSummaryRepository : ReactiveCrudRepository<CqlEt
     fun findByHash(hash: String): Mono<CqlEthereumContractSummary>
 
     @Consistency(value = ConsistencyLevel.LOCAL_QUORUM)
-    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlEthereumContractSummary>
+    fun findAllByHashIn(hashes: Iterable<String>): Flux<CqlEthereumContractSummary> = Flux.fromIterable(hashes)
+        .flatMap { hash -> findByHash(hash) }
 
     /**
      * Return {@code true} if update was successful.

--- a/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/BitcoinContractSummaryStorage.kt
+++ b/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/BitcoinContractSummaryStorage.kt
@@ -15,7 +15,7 @@ class BitcoinContractSummaryStorage(
     override fun findById(id: String): Mono<CqlBitcoinContractSummary> = contractSummaryRepository.findByHash(id)
 
     override fun findAllByIdIn(ids: Iterable<String>): Flux<CqlBitcoinContractSummary> = contractSummaryRepository
-            .findAllByHashIn(ids)
+            .findAllByHash(ids)
 
     override fun update(summary: CqlBitcoinContractSummary, oldVersion: Long): Mono<Boolean> = contractSummaryRepository
             .update(summary, oldVersion)

--- a/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/delta/apply/BitcoinTxConsumerConfiguration.kt
+++ b/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/delta/apply/BitcoinTxConsumerConfiguration.kt
@@ -29,6 +29,8 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 private const val MAX_POLL_RECORDS_CONFIG = 500
+private const val MAX_POLL_INTERVAL_MS_CONFIG = 20000
+private const val SESSION_TIMEOUT_MS_CONFIG = 30000
 
 @EnableKafka
 @Configuration
@@ -79,6 +81,8 @@ class BitcoinTxConsumerConfiguration {
             ConsumerConfig.GROUP_ID_CONFIG to "bitcoin-contract-summary-update-process",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to IsolationLevel.READ_COMMITTED.toString().toLowerCase(),
-            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG,
+            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS_CONFIG,
+            ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to SESSION_TIMEOUT_MS_CONFIG
     )
 }

--- a/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/delta/apply/BitcoinTxConsumerConfiguration.kt
+++ b/contract-summary/bitcoin/src/main/kotlin/fund/cyber/contract/bitcoin/delta/apply/BitcoinTxConsumerConfiguration.kt
@@ -29,7 +29,6 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 private const val MAX_POLL_RECORDS_CONFIG = 500
-private const val MAX_POLL_INTERVAL_MS_CONFIG = 20000
 private const val SESSION_TIMEOUT_MS_CONFIG = 30000
 
 @EnableKafka
@@ -82,7 +81,6 @@ class BitcoinTxConsumerConfiguration {
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.ISOLATION_LEVEL_CONFIG to IsolationLevel.READ_COMMITTED.toString().toLowerCase(),
             ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG,
-            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS_CONFIG,
             ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to SESSION_TIMEOUT_MS_CONFIG
     )
 }

--- a/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/EthereumContractSummaryStorage.kt
+++ b/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/EthereumContractSummaryStorage.kt
@@ -15,7 +15,7 @@ class EthereumContractSummaryStorage(
     override fun findById(id: String): Mono<CqlEthereumContractSummary> = contractSummaryRepository.findByHash(id)
 
     override fun findAllByIdIn(ids: Iterable<String>): Flux<CqlEthereumContractSummary> = contractSummaryRepository
-            .findAllByHashIn(ids)
+            .findAllByHash(ids)
 
     override fun update(summary: CqlEthereumContractSummary, oldVersion: Long): Mono<Boolean>
             = contractSummaryRepository.update(summary, oldVersion)

--- a/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/delta/apply/EthereumConsumerConfiguration.kt
+++ b/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/delta/apply/EthereumConsumerConfiguration.kt
@@ -35,6 +35,8 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 private const val MAX_POLL_RECORDS_CONFIG = 500
+private const val MAX_POLL_INTERVAL_MS_CONFIG = 20000
+private const val SESSION_TIMEOUT_MS_CONFIG = 30000
 
 @EnableKafka
 @Configuration
@@ -71,13 +73,13 @@ class EthereumTxConsumerConfiguration {
     fun txListenerContainer(): ConcurrentMessageListenerContainer<PumpEvent, EthereumTx> {
 
         val consumerFactory = DefaultKafkaConsumerFactory(
-                consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumTx::class.java)
+            consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumTx::class.java)
         )
 
         val containerProperties = ContainerProperties(chain.txPumpTopic).apply {
             setBatchErrorHandler(SeekToCurrentBatchErrorHandler())
             messageListener = UpdateContractSummaryProcess(contractSummaryStorage, txDeltaProcessor, deltaMerger,
-                    monitoring, kafkaBrokers)
+                monitoring, kafkaBrokers)
             isAckOnError = false
             ackMode = AbstractMessageListenerContainer.AckMode.BATCH
         }
@@ -91,13 +93,13 @@ class EthereumTxConsumerConfiguration {
     fun blockListenerContainer(): ConcurrentMessageListenerContainer<PumpEvent, EthereumBlock> {
 
         val consumerFactory = DefaultKafkaConsumerFactory(
-                consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumBlock::class.java)
+            consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumBlock::class.java)
         )
 
         val containerProperties = ContainerProperties(chain.blockPumpTopic).apply {
             setBatchErrorHandler(SeekToCurrentBatchErrorHandler())
             messageListener = UpdateContractSummaryProcess(contractSummaryStorage, blockDeltaProcessor, deltaMerger,
-                    monitoring, kafkaBrokers)
+                monitoring, kafkaBrokers)
             isAckOnError = false
             ackMode = AbstractMessageListenerContainer.AckMode.BATCH
         }
@@ -111,13 +113,13 @@ class EthereumTxConsumerConfiguration {
     fun uncleListenerContainer(): ConcurrentMessageListenerContainer<PumpEvent, EthereumUncle> {
 
         val consumerFactory = DefaultKafkaConsumerFactory(
-                consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumUncle::class.java)
+            consumerConfigs(), JsonDeserializer(PumpEvent::class.java), JsonDeserializer(EthereumUncle::class.java)
         )
 
         val containerProperties = ContainerProperties(chain.unclePumpTopic).apply {
             setBatchErrorHandler(SeekToCurrentBatchErrorHandler())
             messageListener = UpdateContractSummaryProcess(contractSummaryStorage, uncleDeltaProcessor, deltaMerger,
-                    monitoring, kafkaBrokers)
+                monitoring, kafkaBrokers)
             isAckOnError = false
             ackMode = AbstractMessageListenerContainer.AckMode.BATCH
         }
@@ -128,11 +130,13 @@ class EthereumTxConsumerConfiguration {
     }
 
     private fun consumerConfigs(): MutableMap<String, Any> = defaultConsumerConfig().with(
-            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaBrokers,
-            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
-            ConsumerConfig.GROUP_ID_CONFIG to "ethereum-contract-summary-update-process",
-            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
-            ConsumerConfig.ISOLATION_LEVEL_CONFIG to IsolationLevel.READ_COMMITTED.toString().toLowerCase(),
-            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG
+        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaBrokers,
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+        ConsumerConfig.GROUP_ID_CONFIG to "ethereum-contract-summary-update-process",
+        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
+        ConsumerConfig.ISOLATION_LEVEL_CONFIG to IsolationLevel.READ_COMMITTED.toString().toLowerCase(),
+        ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG,
+        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS_CONFIG,
+        ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to SESSION_TIMEOUT_MS_CONFIG
     )
 }

--- a/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/delta/apply/EthereumConsumerConfiguration.kt
+++ b/contract-summary/ethereum/src/main/kotlin/fund/cyber/contract/ethereum/delta/apply/EthereumConsumerConfiguration.kt
@@ -35,7 +35,6 @@ import org.springframework.kafka.listener.config.ContainerProperties
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 private const val MAX_POLL_RECORDS_CONFIG = 500
-private const val MAX_POLL_INTERVAL_MS_CONFIG = 20000
 private const val SESSION_TIMEOUT_MS_CONFIG = 30000
 
 @EnableKafka
@@ -136,7 +135,6 @@ class EthereumTxConsumerConfiguration {
         ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
         ConsumerConfig.ISOLATION_LEVEL_CONFIG to IsolationLevel.READ_COMMITTED.toString().toLowerCase(),
         ConsumerConfig.MAX_POLL_RECORDS_CONFIG to MAX_POLL_RECORDS_CONFIG,
-        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to MAX_POLL_INTERVAL_MS_CONFIG,
         ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG to SESSION_TIMEOUT_MS_CONFIG
     )
 }


### PR DESCRIPTION
Contract Summary Tx processing stucks.
max.poll.interval.ms & session.timeout.ms increased to 20000ms and 30000ms accordingly (with a large margin till we don't find appropriate values).
Added new metric called `contract_summary_records_processing` to check processing time of records batch. It needed for more accurate tune of max.poll.interval.ms & session.timeout.ms properties.