### PR TITLE
Chain reorganization going wrong

### DIFF
--- a/dev-environment/env.yml
+++ b/dev-environment/env.yml
@@ -28,7 +28,7 @@ services:
 
   elassandra:
     container_name: elassandra-search
-    image: strapdata/elassandra:5.5.0.13
+    image: cybernode/elassandra:5.5.0.19
     ports:
       - "9042:9042"
       - "9200:9200"


### PR DESCRIPTION
The reason was that last checked block was popped out of stack but in fact it have to stay in stack.
Also fixes #241 