### PR TITLE
Fix Kafka tests and use a single Kafka instance per test module

### DIFF
--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/BaseForKafkaIntegrationTest.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/BaseForKafkaIntegrationTest.kt
@@ -4,9 +4,7 @@ import org.apache.kafka.clients.admin.AdminClient
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestInstance
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.kafka.test.context.EmbeddedKafka
-import org.springframework.kafka.test.rule.KafkaEmbedded
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import javax.annotation.PostConstruct
@@ -15,10 +13,10 @@ import javax.annotation.PostConstruct
 @Tag("kafka-integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringJUnitConfig
+@ContextConfiguration(classes = [KafkaEmbeddedHolder::class])
 abstract class BaseKafkaIntegrationTest {
 
-    @Autowired
-    lateinit var embeddedKafka: KafkaEmbedded
+    val embeddedKafka = KafkaEmbeddedHolder.getKafka()
 
     lateinit var adminClient: AdminClient
 
@@ -31,13 +29,6 @@ abstract class BaseKafkaIntegrationTest {
 
 private const val KAFKA_STARTUP_TEST_TOPIC = "KAFKA_STARTUP_TEST_TOPIC"
 
-@EmbeddedKafka(
-    topics = [KAFKA_STARTUP_TEST_TOPIC], partitions = 1,
-    brokerProperties = [
-        "auto.create.topics.enable=false", "transaction.state.log.replication.factor=1",
-        "transaction.state.log.min.isr=1"
-    ]
-)
 @TestPropertySource(properties = ["KAFKA_BROKERS:\${spring.embedded.kafka.brokers}"])
 abstract class BaseKafkaIntegrationTestWithStartedKafka : BaseKafkaIntegrationTest() {
 

--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/KafkaEmbeddedHolder.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/KafkaEmbeddedHolder.kt
@@ -1,0 +1,31 @@
+package fund.cyber.common.kafka
+
+import kafka.common.KafkaException
+import org.springframework.kafka.test.rule.KafkaEmbedded
+
+object KafkaEmbeddedHolder {
+    val embeddedKafka = KafkaEmbedded(1, false)
+    var started = false
+
+    init {
+        Runtime.getRuntime().addShutdownHook(Thread(Runnable(function = {
+            embeddedKafka.destroy()
+        })))
+    }
+
+    fun getKafka(): KafkaEmbedded {
+        if (!started) {
+            try {
+                embeddedKafka.brokerProperty("log.dirs", "./kafka-logs/")
+                embeddedKafka.brokerProperty("auto.create.topics.enable", "true")
+                embeddedKafka.brokerProperty("transaction.state.log.replication.factor", "1")
+                embeddedKafka.brokerProperty("transaction.state.log.min.isr", "1")
+                embeddedKafka.before()
+            } catch (e: Exception) {
+                throw KafkaException(e)
+            }
+            started = true
+        }
+        return embeddedKafka
+    }
+}

--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionLackOfRecordsReaderTest.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionLackOfRecordsReaderTest.kt
@@ -7,18 +7,10 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.kafka.test.context.EmbeddedKafka
 
 
 const val EXISTING_TOPIC_WITH_RECORDS_LACK = "EXISTING_EMPTY_TOPIC"
 
-@EmbeddedKafka(
-    partitions = 1, topics = [EXISTING_TOPIC_WITH_RECORDS_LACK],
-    brokerProperties = [
-        "auto.create.topics.enable=false", "transaction.state.log.replication.factor=1",
-        "transaction.state.log.min.isr=1"
-    ]
-)
 @DisplayName("Single-partitioned topic lack of records reader test")
 class SinglePartitionLackOfRecordsReaderTest : BaseKafkaIntegrationTest() {
 

--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionMultipleTransactionRecordReaderTest.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionMultipleTransactionRecordReaderTest.kt
@@ -7,17 +7,9 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.kafka.test.context.EmbeddedKafka
 
 const val MULTIPLE_TRANSACTION_RECORD_TOPIC = "MULTIPLE_TRANSACTION_RECORD_TOPIC"
 
-@EmbeddedKafka(
-    partitions = 1, topics = [MULTIPLE_TRANSACTION_RECORD_TOPIC],
-    brokerProperties = [
-        "auto.create.topics.enable=false", "transaction.state.log.replication.factor=1",
-        "transaction.state.log.min.isr=1"
-    ]
-)
 @DisplayName("Single-partitioned topic last items reader test")
 class SinglePartitionMultipleTransactionRecordReaderTest : BaseKafkaIntegrationTest() {
 

--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionNonRecordsReaderTest.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionNonRecordsReaderTest.kt
@@ -4,13 +4,11 @@ import fund.cyber.common.kafka.BaseKafkaIntegrationTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.kafka.test.context.EmbeddedKafka
 
 
 const val NON_EXISTING_TOPIC = "NON_EXISTING_TOPIC"
-const val EXISTING_EMPTY_TOPIC = "EXISTING_EMPTY_TOPIC"
+const val EXISTING_EMPTY_TOPIC = "EMPTY_TOPIC"
 
-@EmbeddedKafka(topics = [EXISTING_EMPTY_TOPIC], partitions = 1)
 @DisplayName("Single-partitioned topic without items reader tests")
 class SinglePartitionNonRecordsReaderTest : BaseKafkaIntegrationTest() {
 

--- a/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionSingeTransactionRecordReaderTest.kt
+++ b/common-kafka/src/test/kotlin/fund/cyber/common/kafka/reader/SinglePartitionSingeTransactionRecordReaderTest.kt
@@ -7,18 +7,10 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.kafka.test.context.EmbeddedKafka
 
 
 const val SINGLE_TRANSACTION_RECORD_TOPIC = "SINGLE_TRANSACTION_RECORD_TOPIC"
 
-@EmbeddedKafka(
-    partitions = 1, topics = [SINGLE_TRANSACTION_RECORD_TOPIC],
-    brokerProperties = [
-        "auto.create.topics.enable=false", "transaction.state.log.replication.factor=1",
-        "transaction.state.log.min.isr=1"
-    ]
-)
 @DisplayName("Single-partitioned topic last item reader test")
 class SinglePartitionSingeTransactionRecordReaderTest : BaseKafkaIntegrationTest() {
 


### PR DESCRIPTION
- Explicitly set `log.dirs` property so it does not use OS `/var/` directory
- Share a single Kafka instance per test module

resolves #255 